### PR TITLE
CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,19 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - dev
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest

--- a/.github/workflows/vet-and-test.yml
+++ b/.github/workflows/vet-and-test.yml
@@ -1,7 +1,7 @@
 name: vet&test
 on: [push, pull_request]
 jobs:
-  pre_release:
+  check_correctness:
     runs-on: ubuntu-latest
     env:
       GOPROXY: direct

--- a/.github/workflows/vet-and-test.yml
+++ b/.github/workflows/vet-and-test.yml
@@ -1,0 +1,19 @@
+name: vet&test
+on: [push, pull_request]
+jobs:
+  pre_release:
+    runs-on: ubuntu-latest
+    env:
+      GOPROXY: direct
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: vet
+        run: go vet ./...
+      - name: test
+        run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sadmadrus/chessBox
+
+go 1.19


### PR DESCRIPTION
Раз уж у нас Github с бесплатными Github Actions, давайте пользоваться.

В этом MR:

- `go vet` и `go test` настроены запускаться на каждый push; если будут ошибки, тому, кто делал push, приходит уведомление на почту (остальным вроде бы не должно, если я правильно помню, как это устроено в Github Actions);
- [`golangci-lint`](https://github.com/golangci/golangci-lint) медленнее, поэтому он запускается только для MR и пушей в основные ветки (main и dev);
- Dependabot будет следить за зависимостями и создавать MR, если зависимость можно обновить.